### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
   
   def index
-    # @items = Item.order('created_at DESC')
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -22,7 +22,7 @@ class Item < ApplicationRecord
   validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 },
                     presence: { message: "can't be blank" }
   # ジャンルの選択が「---」の時は保存できないようにする
-  with_options numericality: { other_than: 1, message: "must be other than 1" } do
+  with_options numericality: { other_than: 1, message: 'must be other than 1' } do
     validates :category_id
     validates :item_status_id
     validates :shipping_cost_id

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,27 +123,27 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
+          <%# <div class='sold-out'> %>
+            <%# <span>Sold Out!!</span> %>
+          <%# </div> %>
           <%# //商品が売れていればsold outを表示しましょう %>
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_cost.name%></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -152,10 +152,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+    <% end %>
+      
+    <% if @items.blank? then %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -173,8 +172,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Item, type: :model do
       it 'userが紐づいていないと出品できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
       it '1枚画像がないと出品できない' do
         @item.image = nil
@@ -35,7 +35,7 @@ RSpec.describe Item, type: :model do
       it 'カテゴリの情報に「---」が選択されている場合は出品できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
       it 'カテゴリーの情報が空欄だと出品できない' do
         @item.category_id = nil
@@ -45,7 +45,7 @@ RSpec.describe Item, type: :model do
       it '商品の状態の情報に「---」が選択されている場合は出品できない' do
         @item.item_status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Item status must be other than 1")
+        expect(@item.errors.full_messages).to include('Item status must be other than 1')
       end
       it '商品の状態の情報が空欄だと出品できない' do
         @item.item_status_id = nil
@@ -55,7 +55,7 @@ RSpec.describe Item, type: :model do
       it '配送料の負担の情報に「---」が選択されている場合は出品できない' do
         @item.shipping_cost_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping cost must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping cost must be other than 1')
       end
       it '配送料の負担の情報が空欄だと出品できない' do
         @item.shipping_cost_id = nil
@@ -65,7 +65,7 @@ RSpec.describe Item, type: :model do
       it '発送元の地域の情報に「---」が選択されている場合は出品できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
       end
       it '発送元の地域の情報が空欄だと出品できない' do
         @item.prefecture_id = nil
@@ -75,7 +75,7 @@ RSpec.describe Item, type: :model do
       it '発送までの日数の情報に「---」が選択されている場合は出品できない' do
         @item.shipping_date_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping date must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping date must be other than 1')
       end
       it '発送までの日数の情報が空欄だと出品できない' do
         @item.shipping_date_id = nil


### PR DESCRIPTION
#What
商品一覧表示機能の実装
#Why
出品した商品の情報を一覧表示画面に表示するため
商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/44675e33190d4dc4314ba8d93b2ff4d4
商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/b6f8259783e24fb159ac21ef5dd0ab41